### PR TITLE
Fix ms runtime dependency in JWT util

### DIFF
--- a/auth-api/src/utils/jwt.ts
+++ b/auth-api/src/utils/jwt.ts
@@ -1,5 +1,5 @@
 import jwt, { SignOptions, VerifyOptions } from 'jsonwebtoken';
-import ms from 'ms';
+import type { StringValue } from 'ms';
 
 function getEnvOrThrow(key: string): string {
   const value = process.env[key];
@@ -13,7 +13,7 @@ const JWT_SECRET = getEnvOrThrow('JWT_SECRET');
 const JWT_ALGORITHM = getEnvOrThrow('JWT_ALGORITHM') as jwt.Algorithm;
 const JWT_ISSUER = getEnvOrThrow('JWT_ISSUER');
 const JWT_AUDIENCE = getEnvOrThrow('JWT_AUDIENCE');
-const JWT_EXPIRES_IN = getEnvOrThrow('JWT_EXPIRES_IN') as ms.StringValue;
+const JWT_EXPIRES_IN = getEnvOrThrow('JWT_EXPIRES_IN') as StringValue;
 
 
 const signOptions: SignOptions = {


### PR DESCRIPTION
## Summary
- use type-only import for ms in JWT utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875cbad82d0832c8a7ad61812d5faf8