### PR TITLE
Create shared logging utilities

### DIFF
--- a/shared/context/requestContext.ts
+++ b/shared/context/requestContext.ts
@@ -1,0 +1,46 @@
+import { createNamespace, Namespace } from 'cls-hooked';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+export type RequestContext = {
+  traceId: string;
+  method: string;
+  path: string;
+};
+
+const namespace: Namespace = createNamespace('request');
+
+export const requestContext = {
+  run<T>(context: RequestContext, callback: () => T): T {
+    return namespace.runAndReturn(() => {
+      namespace.set('context', context);
+      return callback();
+    });
+  },
+  getStore(): RequestContext | undefined {
+    return namespace.get('context');
+  },
+};
+
+export function getTraceId(): string {
+  const ctx = requestContext.getStore();
+  return ctx ? ctx.traceId : '';
+}
+
+export default function withRequestContext(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) {
+  const context: RequestContext = {
+    traceId: (req.headers['x-trace-id'] as string) || uuidv4(),
+    method: req.method,
+    path: req.path,
+  };
+
+  requestContext.run(context, () => next());
+}
+
+export function runWithContext(ctx: RequestContext, fn: () => Promise<void> | void) {
+  return requestContext.run(ctx, fn);
+}

--- a/shared/logger/index.ts
+++ b/shared/logger/index.ts
@@ -1,0 +1,71 @@
+import winston, { format, Logger, transports as winstonTransports } from 'winston';
+import LokiTransport from 'winston-loki';
+
+const { combine, timestamp, printf, colorize, errors, json } = format;
+
+const getLogFormat = printf(({ level, message, timestamp, stack, ...meta }) => {
+  const location = meta.file || 'unknown';
+  const method = meta.method || 'anonymous';
+  const line = meta.line || '?';
+  const traceId = meta.traceId ? `[TraceID: ${meta.traceId}]` : '';
+  return `${timestamp} ${traceId} ${level} [${location}:${method}:${line}] → ${stack || message}`;
+});
+
+function disableLogging(logger: Logger) {
+  const noop = (() => {}) as unknown as winston.LeveledLogMethod;
+  logger.info = noop;
+  logger.warn = noop;
+  logger.error = noop;
+  logger.debug = noop;
+  logger.verbose = noop;
+  logger.silly = noop;
+}
+
+export function createLogger(serviceName = 'unknown'): Logger {
+  const logLevel = process.env.LOG_LEVEL || 'info';
+  const isSilent = logLevel === 'off';
+
+  const logger = winston.createLogger({
+    level: isSilent ? 'silent' : logLevel,
+    format: combine(timestamp(), errors({ stack: true }), getLogFormat),
+    transports: [],
+  });
+
+  if (!isSilent) {
+    logger.add(
+      new winstonTransports.Console({
+        format: combine(colorize(), getLogFormat),
+      })
+    );
+
+    logger.add(
+      new winstonTransports.File({
+        filename: 'logs/error.log',
+        level: 'error',
+      })
+    );
+
+    logger.add(
+      new winstonTransports.File({
+        filename: 'logs/combined.log',
+      })
+    );
+
+    logger.add(
+      new LokiTransport({
+        host: 'http://localhost:3100',
+        labels: { service: serviceName },
+        json: true,
+        format: json(),
+      })
+    );
+
+    logger.exceptions.handle(
+      new winstonTransports.File({ filename: 'logs/exceptions.log' })
+    );
+  } else {
+    disableLogging(logger);
+  }
+
+  return logger;
+}

--- a/shared/middlewares/traceId.ts
+++ b/shared/middlewares/traceId.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+import withRequestContext from '../context/requestContext';
+
+export default function traceId(req: Request, res: Response, next: NextFunction) {
+  return withRequestContext(req, res, next);
+}

--- a/shared/types/common.d.ts
+++ b/shared/types/common.d.ts
@@ -1,0 +1,9 @@
+export type ServiceName = 'auth-api' | 'metrics-api' | 'logs-api' | string;
+export type LogLevel =
+  | 'off'
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'verbose'
+  | 'debug'
+  | 'silly';

--- a/shared/utils/getLogLocation.ts
+++ b/shared/utils/getLogLocation.ts
@@ -1,0 +1,19 @@
+export function getLogLocation(depth = 3) {
+  const err = new Error();
+  const stack = err.stack?.split('\n') ?? [];
+  const caller = stack[depth]?.trim();
+  if (!caller) return { file: 'unknown', method: 'anonymous', line: '?' };
+
+  const match = caller.match(/at (?:(.+?) )?\(?(.+):(\d+):(\d+)\)?/);
+
+  if (!match) return { file: 'unknown', method: 'anonymous', line: '?' };
+
+  const [, method = 'anonymous', filePath, line, column] = match;
+  const file = filePath.split('/').pop() || filePath;
+
+  return {
+    file,
+    method,
+    line: `${line}:${column}`,
+  };
+}


### PR DESCRIPTION
## Summary
- add request context helper using cls-hooked
- expose logger factory in shared module
- include traceId Express middleware
- add stack location helper
- define basic shared types

## Testing
- `npm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68772814eb18832c8d908f03b90418d8