### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/auth-api/package-lock.json
+++ b/auth-api/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.2",
         "prom-client": "^15.1.3",
         "uuid": "^11.1.0",
@@ -3658,6 +3659,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4202,6 +4221,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/auth-api/package.json
+++ b/auth-api/package.json
@@ -26,7 +26,8 @@
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "winston-loki": "^6.1.3"
+    "winston-loki": "^6.1.3",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/auth-api/src/routes/auth.routes.ts
+++ b/auth-api/src/routes/auth.routes.ts
@@ -1,11 +1,18 @@
+import rateLimit from 'express-rate-limit';
 import { Router } from 'express';
 import { authenticate } from '../middlewares/auth.middleware';
 import { login, me, register } from '../controllers/auth.controller';
 
 const router = Router();
 
+// Define rate limiter: maximum of 10 requests per minute for the /me route
+const meRateLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 10, // limit each IP to 10 requests per windowMs
+});
+
 router.post('/register', register);
 router.post('/login', login);
-router.get('/me', authenticate, me);
+router.get('/me', meRateLimiter, authenticate, me);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Mohan-01/PluseHive/security/code-scanning/1](https://github.com/Mohan-01/PluseHive/security/code-scanning/1)

To fix the missing rate limiting issue, we will use the `express-rate-limit` package to apply rate limiting to the `/me` route. This will limit the number of requests a client can make to this endpoint within a specific time window, mitigating the risk of denial-of-service attacks. The changes involve:

1. Installing and importing the `express-rate-limit` package.
2. Creating a rate limiter instance configured with a reasonable request limit and time window.
3. Applying the rate limiter specifically to the `/me` route using `.get()`.

These changes will only impact the `/me` route, leaving the other routes unaffected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
